### PR TITLE
Add plausible analytics, information about pausible and a link to the repo

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,0 +1,36 @@
+import { FormattedMessage } from "react-intl";
+import styles from "./Footer.module.css";
+
+export const Footer = () => (
+  <footer>
+    <small className={styles.credit}>
+      <FormattedMessage
+        id="iconCredits"
+        values={{
+          eucalyp: (
+            <a href="https://www.flaticon.com/authors/eucalyp">Eucalyp</a>
+          ),
+          flaticon: <a href="https://www.flaticon.com/">Flaticon</a>,
+        }}
+      />
+    </small>
+    <small className={styles.credit}>
+      <FormattedMessage
+        id="analyticsCredits"
+        values={{
+          plausible: <a href="https://plausible.io">Plausible</a>,
+        }}
+      />
+    </small>
+    <small className={styles.credit}>
+      <FormattedMessage
+        id="openSource"
+        values={{
+          github: (
+            <a href="https://github.com/keeganmcbride/piirangud">GitHub</a>
+          ),
+        }}
+      />
+    </small>
+  </footer>
+);

--- a/components/Footer.module.css
+++ b/components/Footer.module.css
@@ -1,0 +1,7 @@
+.credit {
+  display: block;
+}
+
+.credit + .credit {
+  margin-top: 8px;
+}

--- a/components/RegulationPage.js
+++ b/components/RegulationPage.js
@@ -5,12 +5,14 @@ import { parse } from "date-fns";
 import styles from "./Page.module.css";
 import { Regulations } from "./Regulations";
 import { Notice } from "./Notice";
+import { Footer } from "./Footer";
 
 export const RegulationPage = ({ regulations, metadata, notice }) => {
   const { locale } = useIntl();
   return (
     <>
       <Meta />
+      <PlausibleAnalytics />
       <div className={styles.container}>
         <Header locale={locale} metadata={metadata} />
         <main className={styles.main}>
@@ -21,23 +23,22 @@ export const RegulationPage = ({ regulations, metadata, notice }) => {
           </h2>
           <Sources sources={metadata.sources} />
         </main>
-        <footer>
-          <small>
-            <FormattedMessage
-              id="iconCredits"
-              values={{
-                eucalyp: (
-                  <a href="https://www.flaticon.com/authors/eucalyp">Eucalyp</a>
-                ),
-                flaticon: <a href="https://www.flaticon.com/">Flaticon</a>,
-              }}
-            />
-          </small>
-        </footer>
+        <Footer />
       </div>
     </>
   );
 };
+
+const PlausibleAnalytics = () => (
+  <Head>
+    <script
+      async
+      defer
+      data-domain="piirangud.ee"
+      src="https://plausible.io/js/plausible.js"
+    />
+  </Head>
+);
 
 const Header = ({ locale, metadata }) => {
   const intl = useIntl();

--- a/translations/en.json
+++ b/translations/en.json
@@ -2,6 +2,8 @@
   "title": "Current restrictions",
   "metaDescription": "Read the restrictions imposed by the Estonian government regarding the COVID-19 pandemic",
   "time": "As of {time}",
+  "sources": "Sources",
   "iconCredits": "Icons made by {eucalyp} from {flaticon}",
-  "sources": "Sources"
+  "analyticsCredits": "We're using privacy-friendly analytics by {plausible}",
+  "openSource": "This page is open source on {github}"
 }

--- a/translations/et.json
+++ b/translations/et.json
@@ -2,6 +2,8 @@
   "title": "Kehtivad piirangud",
   "metaDescription": "Loe Eesti valitsuse kehtestatud piiranguid seoses COVID-19 pandeemiaga",
   "time": "Seisuga {time}",
+  "sources": "Allikad",
   "iconCredits": "Ikoonide autor: {eucalyp} lehel {flaticon}",
-  "sources": "Allikad"
+  "analyticsCredits": "Me kasutame {plausible} privaatsussõbralikku analüütikat",
+  "openSource": "Lähtekood on avalik lehel {github}"
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -2,6 +2,8 @@
   "title": "Текущие ограничения",
   "metaDescription": "Ознакомьтесь с ограничениями, введенными правительством Эстонии в связи с пандемией COVID-19",
   "time": "C {time}",
+  "sources": "Источники",
   "iconCredits": "Автор иконок: {eucalyp} от {flaticon}",
-  "sources": "Источники"
+  "analyticsCredits": "We're using privacy-friendly analytics by {plausible}",
+  "openSource": "This page is open source on {github}"
 }


### PR DESCRIPTION
Adds the plausible analytics script along with credits to it in the footer and a link to the piirangud repository.

Still need russian translations, but non-critical.